### PR TITLE
setting content type to HTML including simple markup

### DIFF
--- a/web.go
+++ b/web.go
@@ -80,7 +80,7 @@ func ReadyHandler(w http.ResponseWriter, r *http.Request) {
 
 //RootHandler default route
 func RootHandler(w http.ResponseWriter, r *http.Request) {
-
 	w.WriteHeader(http.StatusOK)
-	fmt.Fprintf(w, "Hello I am a cache for you !")
+	w.Header().Add("Content-Type", "text/html")
+	fmt.Fprintf(w, "<h1>K8s-cache</h1><a href='https://github.com/PedroMsTavares/k8s-cache'>https://github.com/PedroMsTavares/k8s-cache</a>")
 }


### PR DESCRIPTION
**Reason**

Working as an SRE and displaying all virtual services in Istio, sometimes I click through to the route of the service to see what it is. 

This small change is to just help people who are unfamiliar with `k8s-cache` to understand it better and where they can learn more.